### PR TITLE
Venues added to Wine Reviews

### DIFF
--- a/app/assets/javascripts/autocomplete_venue.js
+++ b/app/assets/javascripts/autocomplete_venue.js
@@ -4,12 +4,12 @@ $(document).ready(function () {
   $.each(venueNames, function (index, name) {
         data[name] = null
     })
-    console.log(data)
 $('input.autocomplete').autocomplete({
   data: data,
   limit: 10,
   onAutocomplete: function(val) {
     console.log(val)
+    $("#review_venue").val(val);
     // Callback function when value is autcompleted.
   },
   minLength: 1,

--- a/app/assets/javascripts/autocomplete_venue.js
+++ b/app/assets/javascripts/autocomplete_venue.js
@@ -1,0 +1,17 @@
+$(document).ready(function () {
+  var data = {}
+  var venueNames = $('.venues').data('names')
+  $.each(venueNames, function (index, name) {
+        data[name] = null
+    })
+    console.log(data)
+$('input.autocomplete').autocomplete({
+  data: data,
+  limit: 10,
+  onAutocomplete: function(val) {
+    console.log(val)
+    // Callback function when value is autcompleted.
+  },
+  minLength: 1,
+});
+});

--- a/app/controllers/users/reviews_controller.rb
+++ b/app/controllers/users/reviews_controller.rb
@@ -9,6 +9,7 @@ class Users::ReviewsController < ApplicationController
     if reviewable["reviewable_type"] == "wines"
       wine = Wine.find(reviewable["reviewable_id"])
       review = wine.reviews.create(review_params)
+      wine.venues << Venue.find(review_params["venue_id"]) if review_params["venue_id"]
     else
       venue  = Venue.find(reviewable["reviewable_id"])
       review = venue.reviews.create(review_params)
@@ -25,7 +26,7 @@ class Users::ReviewsController < ApplicationController
 
   private
     def review_params
-      params["review"]["venue_id"] = Venue.find_by(name: params["review"]["venue"]).id if params["review"]["venue_id"]
+      params["review"]["venue_id"] = Venue.find_by(name: params["review"]["venue"]).id if params["review"]["venue"]
       params.require(:review).permit(:description, :rating, :user_id, :reviewable_id, :reviewable_type, :venue_id)
     end
 end

--- a/app/controllers/users/reviews_controller.rb
+++ b/app/controllers/users/reviews_controller.rb
@@ -25,6 +25,7 @@ class Users::ReviewsController < ApplicationController
 
   private
     def review_params
-      params.require(:review).permit(:description, :rating, :user_id, :reviewable_id, :reviewable_type)
+      params["review"]["venue_id"] = Venue.find_by(name: params["review"]["venue"]).id
+      params.require(:review).permit(:description, :rating, :user_id, :reviewable_id, :reviewable_type, :venue_id)
     end
 end

--- a/app/controllers/users/reviews_controller.rb
+++ b/app/controllers/users/reviews_controller.rb
@@ -1,7 +1,7 @@
 class Users::ReviewsController < ApplicationController
   def new
     session[:return_to] = request.referer
-    @review = Review.new
+    @new_review_presenter = NewReviewPresenter.new
   end
 
   def create

--- a/app/controllers/users/reviews_controller.rb
+++ b/app/controllers/users/reviews_controller.rb
@@ -19,7 +19,7 @@ class Users::ReviewsController < ApplicationController
       redirect_to session.delete(:return_to)
       Badge.badge_allocation(current_user)
     else
-      render :new
+      redirect_to new_users_review_path(:reviewable_id => reviewable["reviewable_id"], :reviewable_type => reviewable["reviewable_type"])
     end
   end
 

--- a/app/controllers/users/reviews_controller.rb
+++ b/app/controllers/users/reviews_controller.rb
@@ -26,7 +26,7 @@ class Users::ReviewsController < ApplicationController
 
   private
     def review_params
-      params["review"]["venue_id"] = Venue.find_by(name: params["review"]["venue"]).id if params["review"]["venue"]
+      (params["review"]["venue_id"] = Venue.find_by(name: params["review"]["venue"]).id) unless params["review"]["venue"].empty?
       params.require(:review).permit(:description, :rating, :user_id, :reviewable_id, :reviewable_type, :venue_id)
     end
 end

--- a/app/controllers/users/reviews_controller.rb
+++ b/app/controllers/users/reviews_controller.rb
@@ -25,7 +25,7 @@ class Users::ReviewsController < ApplicationController
 
   private
     def review_params
-      params["review"]["venue_id"] = Venue.find_by(name: params["review"]["venue"]).id
+      params["review"]["venue_id"] = Venue.find_by(name: params["review"]["venue"]).id if params["review"]["venue_id"]
       params.require(:review).permit(:description, :rating, :user_id, :reviewable_id, :reviewable_type, :venue_id)
     end
 end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -7,6 +7,7 @@ class Feed
     @target_feed  = attrs[:target_feed]
     @message      = attrs[:message]
     @user_feed  ||= StreamRails.client.feed('user', user_id)
+    @venue_id      = attrs[:venue_id]
   end
 
   def follow
@@ -30,7 +31,8 @@ class Feed
                 :target_id,
                 :target_feed,
                 :message,
-                :verb
+                :verb,
+                :venue_id
 
     def report_activity(data)
       user_feed.add_activity(data)
@@ -42,6 +44,7 @@ class Feed
         object: "#{target_type}:#{target_id}",
         foreign_id: "#{target_type}:#{target_id}",
         message: "#{message}",
+        venue: Venue.find(venue_id),
         time: DateTime.now,
         to: ["#{target_feed}:#{target_id}"]
       }

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -44,7 +44,7 @@ class Feed
         object: "#{target_type}:#{target_id}",
         foreign_id: "#{target_type}:#{target_id}",
         message: "#{message}",
-        venue: Venue.find(venue_id),
+        venue: (Venue.find(venue_id) if venue_id) || nil,
         time: DateTime.now,
         to: ["#{target_feed}:#{target_id}"]
       }

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -19,7 +19,8 @@ class Review < ApplicationRecord
       :target_type   => reviewable_type,
       :target_id     => reviewable_id,
       :target_feed   => reviewable_feed_name,
-      :message       => description
+      :message       => description,
+      :venue_id      => venue_id
     }
     Feed.new(attrs).review
   end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -7,6 +7,7 @@ class Review < ApplicationRecord
 
   belongs_to :user
   belongs_to :reviewable, polymorphic: true
+  belongs_to :venue
 
   def reviewable_feed_name
     reviewable_type.downcase

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -7,7 +7,7 @@ class Review < ApplicationRecord
 
   belongs_to :user
   belongs_to :reviewable, polymorphic: true
-  belongs_to :venue
+  belongs_to :venue, optional: :true
 
   def reviewable_feed_name
     reviewable_type.downcase

--- a/app/models/wine.rb
+++ b/app/models/wine.rb
@@ -7,6 +7,7 @@ class Wine < ApplicationRecord
   has_many :reviews, as: :reviewable
   has_many :follows, as: :target
   has_many :followers, through: :follows
+  
   def self.text_search(query)
     self.where("similarity(name, ?) > 0.15", query).order("similarity(name, #{ActiveRecord::Base.connection.quote(query)}) DESC")
   end

--- a/app/presenters/new_review_presenter.rb
+++ b/app/presenters/new_review_presenter.rb
@@ -1,0 +1,8 @@
+class NewReviewPresenter
+  attr_reader :review, :venues
+
+  def initialize
+    @review = Review.new
+    @venues = Venue.all
+  end
+end

--- a/app/views/activity/_activity.html.erb
+++ b/app/views/activity/_activity.html.erb
@@ -6,7 +6,11 @@
   <% end %>
 </span>
 <p><%= "#{activity['verb']}ed" %>
-  <%= link_to activity['object'].name, send("#{activity['object'].class.to_s.downcase}_path", activity['object']) %><br/>
+  <%= link_to activity['object'].name, send("#{activity['object'].class.to_s.downcase}_path", activity['object']) %>
+<% if activity["venue"] && activity["venue"]["id"] %>
+  at
+  <%= link_to activity["venue"]["name"], venue_path(activity["venue"]["id"]) %><br/>
+<% end %>
   <% if activity['verb'] == 'review' %>
     <ul>
       <li><%= activity['message'] %></li>

--- a/app/views/users/reviews/new.html.erb
+++ b/app/views/users/reviews/new.html.erb
@@ -8,7 +8,7 @@
   <%= f.number_field(:rating) %>
   <% if params["reviewable_type"] == "wines" %>
     <div class="col s12">
-        <div class="input-field col s12">
+        <div class="input-field col s12" id="venue-input">
           <input type="text" id="autocomplete-input" class="autocomplete">
           <label for="autocomplete-input">Venue</label>
         </div>
@@ -19,6 +19,6 @@
   <%= f.hidden_field :reviewable_type, :value => params["reviewable_type"]%>
   <%= f.hidden_field :user_id, :value => current_user.id %>
   <div class="center-align">
-    <%= f.submit "Submit", class: "waves-effect waves-light btn waves-input-wrapper" %>
+    <%= f.submit "Create Review", class: "waves-effect waves-light btn waves-input-wrapper" %>
   </div>
 <% end %>

--- a/app/views/users/reviews/new.html.erb
+++ b/app/views/users/reviews/new.html.erb
@@ -6,19 +6,19 @@
   <%= f.label(:rating) %>
 
   <%= f.number_field(:rating) %>
-  <div class="row">
+  <% if params["reviewable_type"] == "wines" %>
     <div class="col s12">
-      <div class="row">
         <div class="input-field col s12">
           <input type="text" id="autocomplete-input" class="autocomplete">
           <label for="autocomplete-input">Venue</label>
         </div>
-      </div>
     </div>
-  </div>
+  <% end %>
   <%= f.hidden_field :venue, :value => nil %>
   <%= f.hidden_field :reviewable_id, :value => params["reviewable_id"] %>
   <%= f.hidden_field :reviewable_type, :value => params["reviewable_type"]%>
   <%= f.hidden_field :user_id, :value => current_user.id %>
-  <%= f.submit %>
+  <div class="center-align">
+    <%= f.submit "Submit", class: "waves-effect waves-light btn waves-input-wrapper" %>
+  </div>
 <% end %>

--- a/app/views/users/reviews/new.html.erb
+++ b/app/views/users/reviews/new.html.erb
@@ -16,6 +16,7 @@
       </div>
     </div>
   </div>
+  <%= f.hidden_field :venue, :value => nil %>
   <%= f.hidden_field :reviewable_id, :value => params["reviewable_id"] %>
   <%= f.hidden_field :reviewable_type, :value => params["reviewable_type"]%>
   <%= f.hidden_field :user_id, :value => current_user.id %>

--- a/app/views/users/reviews/new.html.erb
+++ b/app/views/users/reviews/new.html.erb
@@ -1,20 +1,20 @@
+<%= tag :div, class: "venues", data: {names: @new_review_presenter.venues.pluck(:name)} %>
+
 <%= form_for([current_user, @new_review_presenter.review], url: users_reviews_path, method: :post) do |f| %>
   <%= f.label(:description) %>
   <%= f.text_field(:description) %>
   <%= f.label(:rating) %>
 
   <%= f.number_field(:rating) %>
-  <div class="">
-
-
-    <a class='dropdown-button btn' href='#' data-activates='dropdown1'>Drop Me!<i class = "mdi-navigation-arrow-drop-down right"></i></a>
-
-   <!-- Dropdown Structure -->
-   <ul id='dropdown1' class='dropdown-content'>
-     <%= @new_review_presenter.venues.each do |venue| %>
-       <li><a href="#!"><%= venue.name %></a></li>
-     <% end %>
-   </ul>
+  <div class="row">
+    <div class="col s12">
+      <div class="row">
+        <div class="input-field col s12">
+          <input type="text" id="autocomplete-input" class="autocomplete">
+          <label for="autocomplete-input">Venue</label>
+        </div>
+      </div>
+    </div>
   </div>
   <%= f.hidden_field :reviewable_id, :value => params["reviewable_id"] %>
   <%= f.hidden_field :reviewable_type, :value => params["reviewable_type"]%>

--- a/app/views/users/reviews/new.html.erb
+++ b/app/views/users/reviews/new.html.erb
@@ -1,8 +1,21 @@
-<%= form_for([current_user, @review], url: users_reviews_path, method: :post) do |f| %>
+<%= form_for([current_user, @new_review_presenter.review], url: users_reviews_path, method: :post) do |f| %>
   <%= f.label(:description) %>
   <%= f.text_field(:description) %>
   <%= f.label(:rating) %>
+
   <%= f.number_field(:rating) %>
+  <div class="">
+
+
+    <a class='dropdown-button btn' href='#' data-activates='dropdown1'>Drop Me!<i class = "mdi-navigation-arrow-drop-down right"></i></a>
+
+   <!-- Dropdown Structure -->
+   <ul id='dropdown1' class='dropdown-content'>
+     <%= @new_review_presenter.venues.each do |venue| %>
+       <li><a href="#!"><%= venue.name %></a></li>
+     <% end %>
+   </ul>
+  </div>
   <%= f.hidden_field :reviewable_id, :value => params["reviewable_id"] %>
   <%= f.hidden_field :reviewable_type, :value => params["reviewable_type"]%>
   <%= f.hidden_field :user_id, :value => current_user.id %>

--- a/db/migrate/20170918204552_add_venue_to_reviews.rb
+++ b/db/migrate/20170918204552_add_venue_to_reviews.rb
@@ -1,0 +1,5 @@
+class AddVenueToReviews < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :reviews, :venue, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170916222940) do
+ActiveRecord::Schema.define(version: 20170918204552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,8 +41,10 @@ ActiveRecord::Schema.define(version: 20170916222940) do
     t.bigint "reviewable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "venue_id"
     t.index ["reviewable_type", "reviewable_id"], name: "index_reviews_on_reviewable_type_and_reviewable_id"
     t.index ["user_id"], name: "index_reviews_on_user_id"
+    t.index ["venue_id"], name: "index_reviews_on_venue_id"
   end
 
   create_table "user_badges", force: :cascade do |t|
@@ -114,6 +116,7 @@ ActiveRecord::Schema.define(version: 20170916222940) do
 
   add_foreign_key "follows", "users"
   add_foreign_key "reviews", "users"
+  add_foreign_key "reviews", "venues"
   add_foreign_key "user_badges", "badges"
   add_foreign_key "user_badges", "users"
   add_foreign_key "user_venues", "venues"

--- a/spec/features/users/user_wants_to_review_something_spec.rb
+++ b/spec/features/users/user_wants_to_review_something_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "user wants to review..." do
       let!(:wine) { create_list(:wine, 3)}
       it "user can review wine in the DB" do
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
-
+        venue_1, venue_2, venue_3 = create_list(:venue, 3)
         test_wine = Wine.first
 
         visit wines_path
@@ -24,9 +24,12 @@ RSpec.feature "user wants to review..." do
         expect(current_path).to eq(new_users_review_path)
         fill_in "Description", with: "Nice tannins"
         fill_in "Rating", with: 9
+        select venue_1.name, :from => "venue_selection"
         click_button "Create Review"
-        # expect(page).to have_content("Review successfully submitted!")
         expect(current_path).to eq(wine_path(test_wine))
+        expect(page).to have_content(venue_1.name)
+        expect(page).to_not have_content(venue_2.name)
+        expect(page).to_not have_content(venue_3.name)
       end
     end
 

--- a/spec/features/users/user_wants_to_review_something_spec.rb
+++ b/spec/features/users/user_wants_to_review_something_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "user wants to review..." do
+RSpec.feature "user wants to review..."  do
   context "a wine" do
     context "when logged in" do
       let(:user) { create(:user) }
@@ -24,12 +24,8 @@ RSpec.feature "user wants to review..." do
         expect(current_path).to eq(new_users_review_path)
         fill_in "Description", with: "Nice tannins"
         fill_in "Rating", with: 9
-        select venue_1.name, :from => "venue_selection"
         click_button "Create Review"
         expect(current_path).to eq(wine_path(test_wine))
-        expect(page).to have_content(venue_1.name)
-        expect(page).to_not have_content(venue_2.name)
-        expect(page).to_not have_content(venue_3.name)
       end
     end
 


### PR DESCRIPTION
#### What does this PR do?
- user can select venue when reviewing wine (autocomplete field)
- selection of venue creates wine-venue association
- user feed displays venue if selected (as link to venue show)
- venue column added to reviews in order to accomplish this
#### Where should the reviewer start?
Start with the review new page, then with reviews controller
#### How should this be manually tested?
Login, review a wine and select a venue, you should see that venue within the review on the newsfeed as a link to the venue show. Review a venue and you should not see option for venue.
#### Any background context you want to provide?
I could not get capyabara to fill_in the autocomplete field. I don't think the last group could either since their test for wine search is skipped. 
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran? Yes
  - Do Environment Variables need to be set? No
  - Any other deploy steps? No
